### PR TITLE
Update read_shape.R

### DIFF
--- a/data-raw/read_shape.R
+++ b/data-raw/read_shape.R
@@ -66,7 +66,7 @@ read_shape <- function(folder_path,
 
   # Import sf object at correct CRS
   sf_object <- sf::read_sf(path) %>%
-    sf::st_set_crs(st_crs(4326))
+    sf::st_transform(4326)
 
   if (grepl("\\.zip$", folder_path)) {
     walk(list.files(path, full.names = TRUE), file.remove)


### PR DESCRIPTION
Using st_set_crs just changes the crs text (as noted in the warning message of st_set_crs)  it doesn't transform it to the proposed 4326. This will actually move the spatial data. The shift is very very minimal in this case but the code is not correct as it is. 
ABS spatial data comes comes in either gda94 or gda2020 reference systems so need to be transformed into wgs84 (crs 4326) using st_transform.
The existing rda files should probably be recreated